### PR TITLE
Improvements for Half Grid Supports

### DIFF
--- a/openvdb/openvdb/math/Math.h
+++ b/openvdb/openvdb/math/Math.h
@@ -74,6 +74,16 @@ template<> inline std::string zeroVal<std::string>() { return ""; }
 /// Return the @c bool value that corresponds to zero.
 template<> inline constexpr bool zeroVal<bool>() { return false; }
 
+
+/// @note Extends the implementation of std::is_arithmetic to support math::half
+template<typename T>
+struct is_arithmetic : std::is_arithmetic<T> {};
+template<>
+struct is_arithmetic<math::half> : std::true_type {};
+// Helper variable template (equivalent to std::is_arithmetic_v)
+template<typename T>
+inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+
 namespace math {
 
 /// @todo These won't be needed if we eliminate StringGrids.
@@ -981,10 +991,11 @@ enum RotationOrder {
     ZXZ_ROTATION
 };
 
-template <typename S, typename T, typename = std::enable_if_t<std::is_arithmetic_v<S>&& std::is_arithmetic_v<T>>>
+template <typename S, typename T, typename = std::enable_if_t<openvdb::is_arithmetic_v<S>&& openvdb::is_arithmetic_v<T>>>
 struct promote {
     using type = typename std::common_type_t<S,T>;
 };
+
 
 /// @brief Return the index [0,1,2] of the smallest value in a 3D vector.
 /// @note This methods assumes operator[] exists.

--- a/openvdb/openvdb/math/Vec3.h
+++ b/openvdb/openvdb/math/Vec3.h
@@ -663,11 +663,13 @@ using Vec3i = Vec3<int32_t>;
 using Vec3ui = Vec3<uint32_t>;
 using Vec3s = Vec3<float>;
 using Vec3d = Vec3<double>;
+using Vec3h = Vec3<math::half>;
 
 OPENVDB_IS_POD(Vec3i)
 OPENVDB_IS_POD(Vec3ui)
 OPENVDB_IS_POD(Vec3s)
 OPENVDB_IS_POD(Vec3d)
+OPENVDB_IS_POD(Vec3h)
 
 } // namespace math
 } // namespace OPENVDB_VERSION_NAME

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -120,11 +120,12 @@ template <typename T> using ToTreeType = typename T::TreeType;
 }
 /// @name Lists of native Tree Types
 /// @{
-using RealTreeTypes    = RealGridTypes::Transform<internal::ToTreeType>;
-using IntegerTreeTypes = IntegerGridTypes::Transform<internal::ToTreeType>;
-using NumericTreeTypes = NumericGridTypes::Transform<internal::ToTreeType>;
-using Vec3TreeTypes    = Vec3GridTypes::Transform<internal::ToTreeType>;
-using TreeTypes        = GridTypes::Transform<internal::ToTreeType>;
+using RealTreeTypes            = RealGridTypes::Transform<internal::ToTreeType>;
+using ExtendedRealTreeTypes    = ExtendedRealGridTypes::Transform<internal::ToTreeType>;
+using IntegerTreeTypes         = IntegerGridTypes::Transform<internal::ToTreeType>;
+using NumericTreeTypes         = NumericGridTypes::Transform<internal::ToTreeType>;
+using Vec3TreeTypes            = Vec3GridTypes::Transform<internal::ToTreeType>;
+using TreeTypes                = GridTypes::Transform<internal::ToTreeType>;
 /// @}
 
 

--- a/openvdb/openvdb/openvdb.h
+++ b/openvdb/openvdb/openvdb.h
@@ -90,7 +90,9 @@ using VectorGrid   = Vec3fGrid;
 /// @name Lists of native Grid Types
 /// @{
 /// The floating point Grid types which OpenVDB will register by default.
-using RealGridTypes   = TypeList<HalfGrid, FloatGrid, DoubleGrid>;
+using RealGridTypes   = TypeList<FloatGrid, DoubleGrid>;
+/// The extended floating point Grid types which OpenVDB will register by default.
+using ExtendedRealGridTypes = RealGridTypes::Append<HalfGrid>;
 /// The integer Grid types which OpenVDB will register by default.
 using IntegerGridTypes = TypeList<Int32Grid, Int64Grid>;
 /// The scalar Grid types which OpenVDB will register by default. This is a

--- a/openvdb/openvdb/tools/LevelSetPlatonic.h
+++ b/openvdb/openvdb/tools/LevelSetPlatonic.h
@@ -314,7 +314,7 @@ createLevelSetPlatonic(int faceCount,float scale, const Vec3f& center,
     float voxelSize, float halfWidth, InterruptT *interrupt)
 {
     // GridType::ValueType is required to be a floating-point scalar.
-    static_assert(std::is_floating_point<typename GridType::ValueType>::value,
+    static_assert(openvdb::is_floating_point<typename GridType::ValueType>::value,
         "level set grids must have scalar, floating-point value types");
 
     const math::Transform::Ptr xform = math::Transform::createLinearTransform( voxelSize );

--- a/openvdb/openvdb/tools/MeshToVolume.h
+++ b/openvdb/openvdb/tools/MeshToVolume.h
@@ -3659,7 +3659,7 @@ meshToVolume(
 
 /// @internal This overload is enabled only for grids with a scalar, floating-point ValueType.
 template<typename GridType, typename Interrupter>
-inline typename std::enable_if<std::is_floating_point<typename GridType::ValueType>::value,
+inline typename std::enable_if<openvdb::is_floating_point<typename GridType::ValueType>::value,
     typename GridType::Ptr>::type
 doMeshConversion(
     Interrupter& interrupter,
@@ -3732,7 +3732,7 @@ doMeshConversion(
 /// @internal This overload is enabled only for grids that do not have a scalar,
 /// floating-point ValueType.
 template<typename GridType, typename Interrupter>
-inline typename std::enable_if<!std::is_floating_point<typename GridType::ValueType>::value,
+inline typename std::enable_if<!openvdb::is_floating_point<typename GridType::ValueType>::value,
     typename GridType::Ptr>::type
 doMeshConversion(
     Interrupter&,

--- a/openvdb/openvdb/tools/VolumeToMesh.h
+++ b/openvdb/openvdb/tools/VolumeToMesh.h
@@ -4621,7 +4621,7 @@ doVolumeToMesh(
     double adaptivity,
     bool relaxDisorientedTriangles)
 {
-    static_assert(std::is_scalar<typename GridType::ValueType>::value,
+    static_assert(openvdb::is_arithmetic<typename GridType::ValueType>::value,
         "volume to mesh conversion is supported only for scalar grids");
 
     VolumeToMesh mesher(isovalue, adaptivity, relaxDisorientedTriangles);

--- a/openvdb/openvdb/unittest/TestMath.cc
+++ b/openvdb/openvdb/unittest/TestMath.cc
@@ -13,6 +13,186 @@ class TestMath: public ::testing::Test
 {
 };
 
+// Testing the operators within the member functions of Vec3
+template<typename ValueT>
+void testMemberOperatorsImpl()
+{
+    using namespace openvdb;
+    using Vec3T = math::Vec3<ValueT>;
+
+    {
+        Vec3T vecA(ValueT(3.14f), ValueT(2.18f), ValueT(-299792458.f));
+
+        // Alternative indexed the elements
+        EXPECT_EQ(vecA(0), ValueT(3.14f));
+        EXPECT_EQ(vecA(1), ValueT(2.18f));
+        EXPECT_EQ(vecA(2), ValueT(-299792458.f));
+
+        // Assignment operator
+        Vec3T vecB = vecA;
+        EXPECT_EQ(vecB(0), vecA(0));
+        EXPECT_EQ(vecB(1), vecA(1));
+        EXPECT_EQ(vecB(2), vecA(2));
+
+        // Negation operator
+        Vec3T vecC = -vecA;
+        EXPECT_EQ(vecC(0), -vecA(0));
+        EXPECT_EQ(vecC(1), -vecA(1));
+        EXPECT_EQ(vecC(2), -vecA(2));
+
+        // Multiply each element of the vector by a scalar
+        Vec3T vecD = vecA;
+        const ValueT gr = ValueT(1.618034f); // golden ratio
+        vecD *= gr;
+        EXPECT_EQ(vecD(0), ValueT(gr * vecA(0)));
+        EXPECT_EQ(vecD(1), ValueT(gr * vecA(1)));
+        EXPECT_EQ(vecD(2), ValueT(gr * vecA(2)));
+
+        // Multiply each element of the vector by the corresponding element
+        Vec3T vecE = vecA;
+        Vec3T vecF(ValueT(-2.5f), ValueT(1.2f), ValueT(3.14159f));
+        vecE *= vecF;
+        EXPECT_EQ(vecE(0), ValueT(vecA(0) * vecF(0)));
+        EXPECT_EQ(vecE(1), ValueT(vecA(1) * vecF(1)));
+        EXPECT_EQ(vecE(2), ValueT(vecA(2) * vecF(2)));
+
+        // Divide each element of the vector by a scalar
+        Vec3T vecG = vecA;
+        vecG /= gr;
+        EXPECT_EQ(vecG(0), ValueT(vecA(0) / gr));
+        EXPECT_EQ(vecG(1), ValueT(vecA(1) / gr));
+        EXPECT_EQ(vecG(2), ValueT(vecA(2) / gr));
+
+        // Divide each element of the vector by the corresponding element of the given vector
+        Vec3T vecH = vecA;
+        vecH /= vecF;
+        EXPECT_EQ(vecH(0), ValueT(vecA(0) / vecF(0)));
+        EXPECT_EQ(vecH(1), ValueT(vecA(1) / vecF(1)));
+        EXPECT_EQ(vecH(2), ValueT(vecA(2) / vecF(2)));
+
+        // Add a scalar to each element of the vector
+        Vec3T vecI = vecA;
+        vecI += gr;
+        EXPECT_EQ(vecI(0), ValueT(vecA(0) + gr));
+        EXPECT_EQ(vecI(1), ValueT(vecA(1) + gr));
+        EXPECT_EQ(vecI(2), ValueT(vecA(2) + gr));
+
+        // Add each element of the given vector to the corresponding element of this vector
+        Vec3T vecJ = vecA;
+        vecJ += vecF;
+        EXPECT_EQ(vecJ(0), ValueT(vecA(0) + vecF(0)));
+        EXPECT_EQ(vecJ(1), ValueT(vecA(1) + vecF(1)));
+        EXPECT_EQ(vecJ(2), ValueT(vecA(2) + vecF(2)));
+
+        // Subtract a scalar from each element of this vector
+        Vec3T vecK = vecA;
+        vecK -= gr;
+        EXPECT_EQ(vecK(0), ValueT(vecA(0) - gr));
+        EXPECT_EQ(vecK(1), ValueT(vecA(1) - gr));
+        EXPECT_EQ(vecK(2), ValueT(vecA(2) - gr));
+
+        // Subtract each element of the given vector from the corresponding element of this vector
+        Vec3T vecL = vecA;
+        vecL -= vecF;
+        EXPECT_EQ(vecL(0), ValueT(vecA(0) - vecF(0)));
+        EXPECT_EQ(vecL(1), ValueT(vecA(1) - vecF(1)));
+        EXPECT_EQ(vecL(2), ValueT(vecA(2) - vecF(2)));
+    }
+}
+
+TEST_F(TestMath, testMemberOperators)
+{
+    using namespace openvdb;
+
+    testMemberOperatorsImpl<math::half>();
+    testMemberOperatorsImpl<float>();
+    testMemberOperatorsImpl<double>();
+}
+
+
+template<typename ValueT>
+void testFreeFunctionsOperatorsImpl()
+{
+    using namespace openvdb;
+    using Vec3T = math::Vec3<ValueT>;
+
+    {
+        Vec3T vecA(ValueT(1),ValueT(2),ValueT(3));
+        Vec3T vecB(ValueT(3),ValueT(4),ValueT(5));
+        const ValueT gr = ValueT(1.618034f); // golden ratio
+
+        /// Check equality operator, does exact floating point comparisons ==
+        bool eqRes = vecA == vecB;
+        EXPECT_FALSE(eqRes);
+
+        /// Check inequality operator, does exact floating point comparisons !=
+        bool ineqRes = vecA != vecB;
+        EXPECT_TRUE(ineqRes);
+
+        /// Check multiplication: scalar * vec
+        Vec3T sclrMultA = gr * vecA;
+        EXPECT_EQ(sclrMultA(0), ValueT(vecA(0) * gr));
+        EXPECT_EQ(sclrMultA(1), ValueT(vecA(1) * gr));
+        EXPECT_EQ(sclrMultA(2), ValueT(vecA(2) * gr));
+
+        /// Check multiplication: vec * scalar
+        Vec3T sclrMultB = vecA * gr;
+        EXPECT_EQ(sclrMultB(0), ValueT(vecA(0) * gr));
+        EXPECT_EQ(sclrMultB(1), ValueT(vecA(1) * gr));
+        EXPECT_EQ(sclrMultB(2), ValueT(vecA(2) * gr));
+
+        /// Check multiplication vec0 * vec1
+        Vec3T multRes = vecA * vecB;
+        EXPECT_EQ(multRes, Vec3T(ValueT(3), ValueT(8), ValueT(15)));
+
+        /// Check: scalar / vec
+        Vec3T sclrDivA = gr / vecA;
+        EXPECT_EQ(sclrDivA(0), ValueT(gr / vecA(0)));
+        EXPECT_EQ(sclrDivA(1), ValueT(gr / vecA(1)));
+        EXPECT_EQ(sclrDivA(2), ValueT(gr / vecA(2)));
+
+        /// Check: vec / scalar
+        Vec3T scalarDivB = vecA / gr;
+        EXPECT_EQ(scalarDivB(0), ValueT(vecA(0) / gr));
+        EXPECT_EQ(scalarDivB(1), ValueT(vecA(1) / gr));
+        EXPECT_EQ(scalarDivB(2), ValueT(vecA(2) / gr));
+
+        /// Check element-wise div: vec0 / vec1
+        Vec3T divRes = vecA / vecB;
+        EXPECT_EQ(divRes(0), ValueT(ValueT(vecA(0)) / ValueT(vecB(0))));
+        EXPECT_EQ(divRes(1), ValueT(ValueT(vecA(1)) / ValueT(vecB(1))));
+        EXPECT_EQ(divRes(2), ValueT(ValueT(vecA(2)) / ValueT(vecB(2))));
+
+        /// Check addition: vec0 + vec1
+        Vec3T addRes = vecA + vecB;
+        EXPECT_EQ(addRes, Vec3T(ValueT(4), ValueT(6), ValueT(8)));
+
+        /// Check scalar addition: a + vec
+        Vec3T addSclrRes = vecA + gr;
+        EXPECT_EQ(addSclrRes(0), ValueT(vecA(0) + gr));
+        EXPECT_EQ(addSclrRes(1), ValueT(vecA(1) + gr));
+        EXPECT_EQ(addSclrRes(2), ValueT(vecA(2) + gr));
+
+        /// Check element-wise subtraction: vec0 - vec1
+        Vec3T subtractRes = vecA - vecB;
+        EXPECT_EQ(subtractRes, Vec3T(ValueT(-2), ValueT(-2), ValueT(-2)));
+
+        /// Check scalar subtraction: vec0 - a
+        Vec3T subSclrRes = vecA - gr;
+        EXPECT_EQ(subSclrRes(0), ValueT(vecA(0) - gr));
+        EXPECT_EQ(subSclrRes(1), ValueT(vecA(1) - gr));
+        EXPECT_EQ(subSclrRes(2), ValueT(vecA(2) - gr));
+    }
+}
+
+TEST_F(TestMath, testFreeFunctionOperators)
+{
+    using namespace openvdb;
+    testFreeFunctionsOperatorsImpl<math::half>();
+    testFreeFunctionsOperatorsImpl<float>();
+    testFreeFunctionsOperatorsImpl<double>();
+}
+
 
 // This suite of tests obviously needs to be expanded!
 TEST_F(TestMath, testAll)
@@ -23,6 +203,7 @@ TEST_F(TestMath, testAll)
         EXPECT_EQ(math::Sign( 3   ), 1);
         EXPECT_EQ(math::Sign(-1.0 ),-1);
         EXPECT_EQ(math::Sign( 0.0f), 0);
+        EXPECT_EQ(math::Sign(math::half(0.)), 0);
     }
     {// SignChange
         EXPECT_TRUE( math::SignChange( -1, 1));


### PR DESCRIPTION
Notable changes:
- Move HalfGrid registration from RealGridTypes to ExtendedRealGridTypes in openvdb.h
- Move HalfTree registration from RealTreeTypes to ExtendedRealTreeTypes in openvdb.h
- Add more support for working with Vec3Half
- Enable tools::volumeToMesh to work with HalfGrid
- Enable tools::meshToVolume to work with HalfGrid
- Enable LevelSetPlatonic in tools to work with HalfGrid